### PR TITLE
Remove overwritten process variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
-var process = require('dotenv').config();
+require('dotenv').config();
 
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('./knexfile')[environment];


### PR DESCRIPTION
Locally running `npm start` broke because we set process equal to the dotenv requirement. 

This may or may not work in production.

Co-Authored-By: Ryan Hantak <rhantak@users.noreply.github.com>