### PR TITLE
Add post /favorites route and start testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('./knexfile')[environment];
 
 var indexRouter = require('./routes/index');
+var favoritesRouter = require('./routes/api/v1/favorites');
 
 var app = express();
 
@@ -18,5 +19,6 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
+app.use('/api/v1/favorites', favoritesRouter);
 
 module.exports = app;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-    testEnvironment: "node"
+    testEnvironment: "node",
+    "automock": false,
+    "setupFiles": [
+        "./setupJest.js"
+    ]
 }

--- a/lib/models/favorite.js
+++ b/lib/models/favorite.js
@@ -3,7 +3,7 @@ class Favorite {
     this.title = track_data.track_name
     this.artistName = track_data.artist_name
     this.genre = track_data.primary_genres.music_genre_list[0].music_genre.music_genre_name || "Unknown"
-    this.rating = track_data.track_rating
+    this.rating = track_data.track_rating // Todo: Check rating is between 0 and 100
   }
 }
 

--- a/lib/models/favorite.js
+++ b/lib/models/favorite.js
@@ -2,8 +2,28 @@ class Favorite {
   constructor(track_data) {
     this.title = track_data.track_name
     this.artistName = track_data.artist_name
-    this.genre = track_data.primary_genres.music_genre_list[0].music_genre.music_genre_name || "Unknown"
-    this.rating = track_data.track_rating // Todo: Check rating is between 0 and 100
+    this.genre = this.checkGenre(track_data.primary_genres.music_genre_list)
+    this.rating = this.checkRating(track_data.track_rating)
+  }
+
+  checkGenre(musicGenreList){
+    if(musicGenreList.length === 0){
+      return "Unknown";
+    } else {
+      return musicGenreList[0].music_genre.music_genre_name;
+    }
+  }
+
+  checkRating(rating){
+    let formattedRating = null;
+    // if MusixMatch is giving us a number outside of their documented range, we're assuming it's not correct
+    // so, if the rating is off, we're storing in the db as null
+    if (rating < 0 || rating > 100 || isNaN(rating)){
+      return formattedRating;
+    } else {
+      // rating IS between 0 and 100, so just keep it!
+      return rating;
+    }
   }
 }
 

--- a/lib/models/favorite.js
+++ b/lib/models/favorite.js
@@ -1,0 +1,10 @@
+class Favorite {
+  constructor(track_data) {
+    this.title = track_data.track_name
+    this.artistName = track_data.artist_name
+    this.genre = track_data.primary_genres.music_genre_list[0].music_genre.music_genre_name || "Unknown"
+    this.rating = track_data.track_rating
+  }
+}
+
+module.exports = Favorite;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,6 +1085,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3054,6 +3063,15 @@
         "jest-util": "^24.9.0"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.1.tgz",
+      "integrity": "sha512-R5GVbQLVjk+PCfzf4vFoYDXt+oCEWuYigyaAnucdeVCXkElAgAYXDFFikHxLyCVjSNDc7TCYQZ1ItLNOE6OCrQ==",
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
@@ -4298,6 +4316,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+    },
     "prompts": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
@@ -5485,6 +5508,11 @@
           }
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,6 +3796,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "~4.16.1",
     "knex": "^0.19.5",
     "morgan": "~1.9.1",
+    "node-fetch": "^2.6.0",
     "pg": "^7.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "jest-fetch-mock": "^3.0.1",
     "knex": "^0.19.5",
     "morgan": "~1.9.1",
     "node-fetch": "^2.6.0",

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,6 +1,9 @@
 var express = require('express');
 var router = express.Router();
 
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
 const fetch = require("node-fetch");
 
 async function fetchMusicData(info) {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,36 @@
+var express = require('express');
+var router = express.Router();
+
+const fetch = require("node-fetch");
+
+async function fetchMusicData(info) {
+  let url = `https://api.musixmatch.com/ws/1.1/track.search?q_track=${info["title"]}&q_artist=${info["artistName"]}&s_artist_rating=desc&s_track_rating=desc&page_size=1&apikey=${process.env.MM_KEY}`
+  let data = await fetch(url)
+    .then(response => response.json())
+    .then(result => {
+      return result.message.body.track_list[0].track;
+    })
+    return data;
+}
+
+router.post('/', (request, response) => {
+  const info = request.body;
+
+  for (let requiredParameter of ["title", "artistName"]) {
+    if (!info[requiredParameter]) {
+      return response
+        .status(422)
+        .send({ "error": `Expected format: { title: <string>, artistName: <string> }. You are missing a ${requiredParameter} property.`})
+    }
+  }
+
+  let musicData = fetchMusicData(info)
+    .then(data => response.send(data))
+  // default no genre to unknown
+  // add fetched data to favorites table
+  // return success response
+  // set condition for returning 400 response
+  // catch 500
+});
+
+module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -5,14 +5,16 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 const fetch = require("node-fetch");
+const Favorite = require("../../../lib/models/favorite")
 
 async function fetchMusicData(info) {
   let url = `https://api.musixmatch.com/ws/1.1/track.search?q_track=${info["title"]}&q_artist=${info["artistName"]}&s_artist_rating=desc&s_track_rating=desc&page_size=1&apikey=${process.env.MM_KEY}`
   let data = await fetch(url)
     .then(response => response.json())
     .then(result => {
-      return result.message.body.track_list[0].track;
+        return result.message.body.track_list;
     })
+    .catch((error) => response.send(500).json({ error: error }))
     return data;
 }
 
@@ -28,12 +30,20 @@ router.post('/', (request, response) => {
   }
 
   let musicData = fetchMusicData(info)
-    .then(data => response.send(data))
-  // default no genre to unknown
-  // add fetched data to favorites table
-  // return success response
-  // set condition for returning 400 response
-  // catch 500
+    .then(data => {
+      if(data.length === 0) {
+        response.status(400).json({
+          "error": "Unable to create favorite.",
+          "detail": "No tracks were found from your search."
+        })
+      } else {
+        let newFavorite = new Favorite(data[0].track)
+
+        database('favorites').insert(newFavorite)
+          .then(response.status(201).send(newFavorite))
+      }
+    })
+    .catch((error) => response.status(500).json({error: error}))
 });
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -39,8 +39,11 @@ router.post('/', (request, response) => {
       } else {
         let newFavorite = new Favorite(data[0].track)
 
-        database('favorites').insert(newFavorite)
-          .then(response.status(201).send(newFavorite))
+        database('favorites')
+          .insert(newFavorite, ["id", "title", "artistName", "genre", "rating"])
+            .then(favoriteInfo =>{
+              response.status(201).send(favoriteInfo[0])
+            })
       }
     })
     .catch((error) => response.status(500).json({error: error}))

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -191,9 +191,41 @@ describe('Test the favorites route', () => {
       expect(res.body).toHaveProperty("rating", 1);
 
     })
-    // 
-    // test('It changes a blank rating to null', aync() => {
-    //
-    // })
+
+    test('It changes a blank rating to null', async() => {
+      let newFav = {
+        title: "Superman (radio remix)",
+        artistName: "LINKIN PARK"
+      }
+
+      await fetch.mockResponseOnce(
+        JSON.stringify({
+          message: {
+            body: {
+              track_list: [{
+                track: {
+                  track_name: "Superman (radio remix)",
+                  artist_name: "LINKIN PARK",
+                  primary_genres: {
+                    music_genre_list: []
+                  }
+                }
+              }]
+            }
+          }
+        })
+      )
+
+      const res = await request(app)
+        .post("/api/v1/favorites")
+        .send(newFav);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty("title", "Superman (radio remix)");
+      expect(res.body).toHaveProperty("artistName", "LINKIN PARK");
+      expect(res.body).toHaveProperty("genre", "Unknown");
+      expect(res.body).toHaveProperty("rating", null);
+
+    })
   })
 });

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -22,8 +22,8 @@ describe('Test the favorites route', () => {
       }
 
       const res = await request(app)
-      .post("/api/v1/favorites")
-      .send(newFav);
+        .post("/api/v1/favorites")
+        .send(newFav);
 
       expect(res.statusCode).toBe(201);
       expect(res.body).toHaveProperty("title", "We Will Rock You");
@@ -45,8 +45,8 @@ describe('Test the favorites route', () => {
       expect(old_favorites.length).toBe(0)
 
       const res = await request(app)
-      .post("/api/v1/favorites")
-      .send(newFav);
+        .post("/api/v1/favorites")
+        .send(newFav);
 
       let new_favorites = await database('favorites').select()
         .then(result => {
@@ -61,8 +61,8 @@ describe('Test the favorites route', () => {
       }
 
       const res = await request(app)
-      .post("/api/v1/favorites")
-      .send(newFav);
+        .post("/api/v1/favorites")
+        .send(newFav);
 
       expect(res.statusCode).toBe(422);
       expect(res.body).toHaveProperty("error", "Expected format: { title: <string>, artistName: <string> }. You are missing a artistName property.");
@@ -75,12 +75,34 @@ describe('Test the favorites route', () => {
       }
 
       const res = await request(app)
-      .post("/api/v1/favorites")
-      .send(newFav);
+        .post("/api/v1/favorites")
+        .send(newFav);
 
       expect(res.statusCode).toBe(400);
       expect(res.body).toHaveProperty("error", "Unable to create favorite.");
       expect(res.body).toHaveProperty("detail", "No tracks were found from your search.");
     })
+
+    test('It changes blank genre to unknown', async() =>{
+      let newFav = {
+        title: "Superman (radio remix)",
+        artistName: "LINKIN PARK"
+      }
+
+      const res = await request(app)
+        .post("/api/v1/favorites")
+        .send(newFav);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty("title", "Superman (radio remix)");
+      expect(res.body).toHaveProperty("artistName", "LINKIN PARK");
+      expect(res.body).toHaveProperty("genre", "Unknown");
+      expect(res.body).toHaveProperty("rating", 1);
+
+    })
+    // 
+    // test('It changes a blank rating to null', aync() => {
+    //
+    // })
   })
 });

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -2,24 +2,85 @@ var shell = require('shelljs');
 var request = require("supertest");
 var app = require('../app');
 
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
 describe('Test the favorites route', () => {
-  // before each and after all database table setup
-  test('It should respond to the POST method', async () => {
-    let newFav = {
-      title: "We will Rock You",
-      artistName: 'Queen'
-    }
-
-    const res = await request(app)
-      .post("/api/v1/favorites")
-        .send(newFav);
-
-    expect(res.statusCode).toBe(201);
-    expect(res.body).toHaveProperty("title", "We Will Rock You");
-    expect(res.body).toHaveProperty("artistName", "Queen");
-    expect(res.body).toHaveProperty("genre", "Rock");
-    expect(res.body).toHaveProperty("rating", 87);
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
   });
-  // Test favorite gets added to the database
-  // Test sad paths
+  afterEach(() => {
+    database.raw('truncate table favorites cascade');
+  });
+
+  describe('POST favorites', () => {
+    test('It should respond to the POST method', async () => {
+      let newFav = {
+        title: "We will Rock You",
+        artistName: 'Queen'
+      }
+
+      const res = await request(app)
+      .post("/api/v1/favorites")
+      .send(newFav);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty("title", "We Will Rock You");
+      expect(res.body).toHaveProperty("artistName", "Queen");
+      expect(res.body).toHaveProperty("genre", "Rock");
+      expect(res.body).toHaveProperty("rating", 87);
+    });
+
+    test('It adds a favorite to the database', async() => {
+      let newFav = {
+        title: "We will Rock You",
+        artistName: 'Queen'
+      }
+
+      let old_favorites = await database('favorites').select()
+        .then(result => {
+          return result;
+        })
+      expect(old_favorites.length).toBe(0)
+
+      const res = await request(app)
+      .post("/api/v1/favorites")
+      .send(newFav);
+
+      let new_favorites = await database('favorites').select()
+        .then(result => {
+          return result;
+        })
+      expect(new_favorites.length).toBe(1)
+    })
+
+    test('It sends an error message for missing parameters', async() => {
+      let newFav = {
+        title: "We will Rock You"
+      }
+
+      const res = await request(app)
+      .post("/api/v1/favorites")
+      .send(newFav);
+
+      expect(res.statusCode).toBe(422);
+      expect(res.body).toHaveProperty("error", "Expected format: { title: <string>, artistName: <string> }. You are missing a artistName property.");
+    })
+
+    test('It sends an error message for no tracks found', async() => {
+      let newFav = {
+        title: "We will Rock You",
+        artistName: "asdf"
+      }
+
+      const res = await request(app)
+      .post("/api/v1/favorites")
+      .send(newFav);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toHaveProperty("error", "Unable to create favorite.");
+      expect(res.body).toHaveProperty("detail", "No tracks were found from your search.");
+    })
+  })
 });

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -1,0 +1,25 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+describe('Test the favorites route', () => {
+  // before each and after all database table setup
+  test('It should respond to the POST method', async () => {
+    let newFav = {
+      title: "We will Rock You",
+      artistName: 'Queen'
+    }
+
+    const res = await request(app)
+      .post("/api/v1/favorites")
+        .send(newFav);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty("title", "We Will Rock You");
+    expect(res.body).toHaveProperty("artistName", "Queen");
+    expect(res.body).toHaveProperty("genre", "Rock");
+    expect(res.body).toHaveProperty("rating", 87);
+  });
+  // Test favorite gets added to the database
+  // Test sad paths
+});


### PR DESCRIPTION
User can now send a `post` request to `/api/v1/favorites` and the favorite is looked up on MusixMatch, added to database, and the info returned in the `response.body` per issue #6 

Also added first test for favorites route. Good thing too, because it showed us we needed to specifically output certain attributes of favorite after adding to db.

Next steps: 
- More testing as commented to check added to database and sad path testing
- Mock API call to MusixMatch so test is not making real API call

Note:
Todo also need to add to `favorite.js` a limit on `rating` to integer between 1-100