### PR TITLE
Add GET /favorites/:id route and tests

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -49,4 +49,18 @@ router.post('/', (request, response) => {
     .catch((error) => response.status(500).json({error: error}))
 });
 
+router.get('/:id', (request, response) =>{
+  database('favorites')
+    .where(request.params)
+    .select('id', 'title', 'artistName', 'genre', 'rating')
+    .then(favorites => {
+      if(favorites.length > 0 ){
+        return response.status(200).send(favorites[0]);
+      } else {
+        return response.status(404).json({error: "No such favorite found"})
+      }
+    })
+    .catch((error) => response.status(500).json({error: error}))
+});
+
 module.exports = router;

--- a/tests/getFavoriteByID.spec.js
+++ b/tests/getFavoriteByID.spec.js
@@ -40,13 +40,33 @@ describe('Test the favorite by id route', () => {
       let favOne = await database('favorites').select('id').first()
 
       const res = await request(app)
-        .get(`/api/v1/favorites/${favOne}`);
+        .get(`/api/v1/favorites/${favOne.id}`);
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toHaveProperty("title", "Hound Dog");
       expect(res.body).toHaveProperty("artistName", "Elvis Presley");
       expect(res.body).toHaveProperty("genre", "Rock");
       expect(res.body).toHaveProperty("rating", 47);
+    })
+
+    test('It should return a 404 if id not in favorites table', async() => {
+      let notAFav = -1
+
+      const res = await request(app)
+        .get(`/api/v1/favorites/${notAFav}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toHaveProperty("error", "No such favorite found");
+    })
+
+    test('It should return a 500 if other error comes up', async() => {
+      let errorFav = 'abc'
+
+      const res = await request(app)
+        .get(`/api/v1/favorites/${errorFav}`);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toHaveProperty("error");
     })
   })
 });

--- a/tests/getFavoriteByID.spec.js
+++ b/tests/getFavoriteByID.spec.js
@@ -1,0 +1,52 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test the favorite by id route', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
+    let favorites = [{
+      title: 'Hound Dog',
+      artistName: 'Elvis Presley',
+      genre: 'Rock',
+      rating: 47
+    },
+    {
+      title: 'Umbrella',
+      artistName: 'Rihanna',
+      genre: 'Pop',
+      rating: 83
+    },
+    {
+      title: 'everything i wanted',
+      artistName: 'Billie Eilish',
+      genre: 'Music',
+      rating: 100
+    }
+    ];
+    await database('favorites').insert(favorites, 'id');
+  });
+  afterEach(() => {
+    database.raw('truncate table favorites cascade');
+  });
+
+  describe('GET favorite by id', () => {
+    test('It should respond to the GET method', async() =>{
+      let favOne = await database('favorites').select('id').first()
+
+      const res = await request(app)
+        .get(`/api/v1/favorites/${favOne}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty("title", "Hound Dog");
+      expect(res.body).toHaveProperty("artistName", "Elvis Presley");
+      expect(res.body).toHaveProperty("genre", "Rock");
+      expect(res.body).toHaveProperty("rating", 47);
+    })
+  })
+});


### PR DESCRIPTION
Added `get api/v1/favorites/:id`, which responds with a json object of the favorite with `:id` from the database. 

Sad paths 
- no `:id` found which returns a 404 response
- `.catch` returns 500 error and can be hit when `:id` is a string instead of an integer

Closes #8 