### PR TITLE
User Cannot Post Duplicate Favorites

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -38,12 +38,21 @@ router.post('/', (request, response) => {
         })
       } else {
         let newFavorite = new Favorite(data[0].track)
-
-        database('favorites')
-          .insert(newFavorite, ["id", "title", "artistName", "genre", "rating"])
-            .then(favoriteInfo =>{
-              response.status(201).send(favoriteInfo[0])
-            })
+        database('favorites').where({'title': newFavorite.title, 'artistName': newFavorite.artistName}).select()
+          .then(faves => {
+            if (!faves.length) {
+              database('favorites')
+              .insert(newFavorite, ["id", "title", "artistName", "genre", "rating"])
+              .then(favoriteInfo =>{
+                response.status(201).send(favoriteInfo[0])
+              })
+            } else {
+              response.status(409).json({
+                "error": "Unable to create favorite.",
+                "detail": "That song is already favorited."
+              })
+            }
+          })
       }
     })
     .catch((error) => response.status(500).json({error: error}))

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -235,7 +235,7 @@ describe('Test the favorites route', () => {
       }
       // set a mock object and stub the fetch call to return a custom object
       // so your fetch call always returns exactly what you want it to return
-      await fetch.mockResponseOnce(
+      await fetch.mockResponse(
         JSON.stringify({
           message: {
             body: {
@@ -263,31 +263,6 @@ describe('Test the favorites route', () => {
       const res_1 = await request(app)
         .post("/api/v1/favorites")
         .send(newFav);
-
-      await fetch.mockResponseOnce(
-        JSON.stringify({
-          message: {
-            body: {
-              track_list: [
-                {
-                  track: {
-                    artist_name: "Queen",
-                    track_name: "We Will Rock You",
-                    track_rating: 87,
-                    primary_genres: {
-                      music_genre_list: [{
-                        music_genre: {
-                          music_genre_name: "Rock"
-                        }
-                      }]
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        })
-      );
 
       const res_2 = await request(app)
         .post("/api/v1/favorites")


### PR DESCRIPTION
- Add check in POST `/favorites` to see if request would cause a duplicate record
- Send a 409 error and refuse to create the favorite if this is the case

Closes #13 