### PR TITLE
Add PUT /playlists/:id endpoint and tests

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -48,6 +48,7 @@ router.post('/', (request, response) => {
 router.put('/:id', (request, response) => {
   const info = request.body;
   const id = request.params;
+
   for (let requiredParameter of ["title"]) {
     if(!info[requiredParameter]) {
       response
@@ -56,15 +57,25 @@ router.put('/:id', (request, response) => {
     }
   }
 
-  database('playlists')
-    .where(id)
-    .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
-    .then(updated => {
-      console.log("made it to updated")
-      response.status(200).send(updated[0]);
+  database('playlists').where(info).select()
+    .then(repeat => {
+      if(repeat.length) {
+        response.status(400).send({
+          "error": "Unable to create playlist.",
+          "detail": "A playlist with that title already exists."
+        })
+      } else {
+        database('playlists')
+        .where(id)
+        .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
+        .then(updated => {
+          response.status(200).send(updated[0])
+        })
+      }
     })
     .catch(error => {
-      response.send(error)
+      console.log(error)
+      response.status(500).json({ error: "Oops, something went wrong!" });
     })
 })
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -45,4 +45,29 @@ router.post('/', (request, response) => {
     .catch(500)
 })
 
+router.put('/:id', (request, response) => {
+  const info = request.body;
+  const id = request.params;
+  for (let requiredParameter of ["title"]) {
+    if(!info[requiredParameter]) {
+      response
+        .status(422)
+        .send({ "error": `Expected format { title: <string> }. You are missing a ${requiredParameter} property.`})
+    }
+  }
+  // check for duplication with another playlist
+  // update playlist in db with id params.id
+  // catch 500 error
+
+  database('playlists')
+    .where(id)
+    .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
+    .then(updated => {
+      response.status(200).send(updated[0]);
+    })
+    .catch(error => {
+      response.send(error)
+    })
+})
+
 module.exports = router;

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -55,14 +55,12 @@ router.put('/:id', (request, response) => {
         .send({ "error": `Expected format { title: <string> }. You are missing a ${requiredParameter} property.`})
     }
   }
-  // check for duplication with another playlist
-  // update playlist in db with id params.id
-  // catch 500 error
 
   database('playlists')
     .where(id)
     .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
     .then(updated => {
+      console.log("made it to updated")
       response.status(200).send(updated[0]);
     })
     .catch(error => {

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -48,7 +48,7 @@ router.post('/', (request, response) => {
 router.put('/:id', (request, response) => {
   const info = request.body;
   const id = request.params;
-
+// check parameters of body
   for (let requiredParameter of ["title"]) {
     if(!info[requiredParameter]) {
       response
@@ -57,22 +57,44 @@ router.put('/:id', (request, response) => {
     }
   }
 
+// check id is in db
+database('playlists')
+  .where(id)
+  .select()
+  .then(results => {
+    if(results.length > 0){
+      return true
+    } else {
+      return response.status(404).send({
+        "error": "Unable to update playlist.",
+        "detail": "A playlist with that id cannot be found"
+      })
+    }
+  })
+  .catch(error => {
+    console.log(error)
+    response.status(500).json({ error: "Oops, something went wrong!" });
+  })
+
+
+// check uniqueness of title
   database('playlists').where(info).select()
     .then(repeat => {
       if(repeat.length) {
         response.status(400).send({
-          "error": "Unable to create playlist.",
+          "error": "Unable to update playlist.",
           "detail": "A playlist with that title already exists."
         })
       } else {
+        // update db
         database('playlists')
-        .where(id)
-        .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
-        .then(updated => {
-          response.status(200).send(updated[0])
-        })
-      }
-    })
+          .where(id)
+          .update(info, ["id", "title", "created_at as createdAt", "updated_at as updatedAt"])
+          .then(updated => {
+            response.status(200).send(updated[0])
+          })
+        }
+      })
     .catch(error => {
       console.log(error)
       response.status(500).json({ error: "Oops, something went wrong!" });

--- a/tests/putPlaylist.spec.js
+++ b/tests/putPlaylist.spec.js
@@ -66,15 +66,15 @@ describe('Test the playlists route', () => {
       let updatedPlaylist = {
         title: "Keep Walking"
       }
-      console.log('playlists', playlists_1)
-      console.log(rockOUT)
+
       const res = await request(app)
         .put(`/api/v1/playlists/${rockOUT.id}`)
         .send(updatedPlaylist);
 
       let playlists = await database('playlists').select()
-      console.log(playlists)
-      expect(playlists.length).toBe(2)
+
+      // when given a title that already exists in the db, no catch is thrown, it simply does not do the update
+      expect(playlists).toStrictEqual(playlists_1)
     });
 
     test('It sends an error for missing parameters', async () => {

--- a/tests/putPlaylist.spec.js
+++ b/tests/putPlaylist.spec.js
@@ -56,7 +56,7 @@ describe('Test the playlists route', () => {
       expect(findRockIN.length).toBe(1)
     });
 
-    test.only('It will only update a unique playlist title', async () => {
+    test('It will only update a unique playlist title', async () => {
       let playlists_1 = await database('playlists').select()
       let rockOUT = await database('playlists')
                             .where({title: 'Rock OUT'})
@@ -72,17 +72,24 @@ describe('Test the playlists route', () => {
         .send(updatedPlaylist);
 
       let playlists = await database('playlists').select()
-
-      // when given a title that already exists in the db, no catch is thrown, it simply does not do the update
+      // when given a title that already exists in the db it  does not do the update
       expect(playlists).toStrictEqual(playlists_1)
+
+      expect(res.body).toHaveProperty("error", "Unable to create playlist.");
+      expect(res.body).toHaveProperty("detail", "A playlist with that title already exists.");
     });
 
     test('It sends an error for missing parameters', async () => {
-      let newPlaylist = {}
+      let rockOUT = await database('playlists')
+                            .where({title: 'Rock OUT'})
+                            .select()
+                            .first()
+
+      let updatedPlaylist = {}
 
       const res = await request(app)
-        .post("/api/v1/playlists")
-        .send(newPlaylist);
+        .put(`/api/v1/playlists/${rockOUT.id}`)
+        .send(updatedPlaylist);
 
       expect(res.statusCode).toBe(422);
       expect(res.body).toHaveProperty("error", "Expected format { title: <string> }. You are missing a title property.");

--- a/tests/putPlaylist.spec.js
+++ b/tests/putPlaylist.spec.js
@@ -75,7 +75,7 @@ describe('Test the playlists route', () => {
       // when given a title that already exists in the db it  does not do the update
       expect(playlists).toStrictEqual(playlists_1)
 
-      expect(res.body).toHaveProperty("error", "Unable to create playlist.");
+      expect(res.body).toHaveProperty("error", "Unable to update playlist.");
       expect(res.body).toHaveProperty("detail", "A playlist with that title already exists.");
     });
 
@@ -94,5 +94,20 @@ describe('Test the playlists route', () => {
       expect(res.statusCode).toBe(422);
       expect(res.body).toHaveProperty("error", "Expected format { title: <string> }. You are missing a title property.");
     });
+
+    test('It sends an error for missing id', async () => {
+      let updatedPlaylist = {
+        title: "Keep Walking"
+      }
+
+      const res = await request(app)
+        .put("/api/v1/playlists/0")
+        .send(updatedPlaylist);
+        
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty("error", "Unable to update playlist.");
+      expect(res.body).toHaveProperty("detail", "A playlist with that id cannot be found");
+    })
+
   });
 });

--- a/tests/putPlaylist.spec.js
+++ b/tests/putPlaylist.spec.js
@@ -1,0 +1,91 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test the playlists route', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+    let playlistsArray = [
+      {
+        "title": "Rock OUT",
+      },
+      {
+        "title": "Keep Walking",
+      }
+    ]
+
+    await database('playlists').insert(playlistsArray, ['id', 'title']);
+
+    fetch.resetMocks();
+  });
+  afterEach(() => {
+    database.raw('truncate table favorites cascade');
+  });
+
+  describe('PUT playlists', () => {
+    test('It should respond to the PUT method', async () => {
+      let rockOUT = await database('playlists').where({title: 'Rock OUT'}).select()
+        .then(results => {
+          return results[0]
+        })
+      let updatePlaylist = {
+        title: "Rock IN"
+      }
+      // drilling down to the id level for rockOUT
+      let rockOUTID = rockOUT.id
+
+      const res = await request(app)
+        .put(`/api/v1/playlists/${rockOUTID}`)
+        .send(updatePlaylist);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty("title", "Rock IN");
+      expect(res.body).toHaveProperty("createdAt");
+      expect(res.body).toHaveProperty("updatedAt");
+      expect(res.body.id).toBe(rockOUT.id);
+
+      let noRockOUT = await database('playlists').where({title: "Rock OUT"}).select()
+      expect(noRockOUT.length).toBe(0)
+
+      let findRockIN = await database('playlists').where({title: "Rock IN"}).select()
+      expect(findRockIN.length).toBe(1)
+    });
+
+    test.only('It will only update a unique playlist title', async () => {
+      let playlists_1 = await database('playlists').select()
+      let rockOUT = await database('playlists')
+                            .where({title: 'Rock OUT'})
+                            .select()
+                            .first()
+
+      let updatedPlaylist = {
+        title: "Keep Walking"
+      }
+      console.log('playlists', playlists_1)
+      console.log(rockOUT)
+      const res = await request(app)
+        .put(`/api/v1/playlists/${rockOUT.id}`)
+        .send(updatedPlaylist);
+
+      let playlists = await database('playlists').select()
+      console.log(playlists)
+      expect(playlists.length).toBe(2)
+    });
+
+    test('It sends an error for missing parameters', async () => {
+      let newPlaylist = {}
+
+      const res = await request(app)
+        .post("/api/v1/playlists")
+        .send(newPlaylist);
+
+      expect(res.statusCode).toBe(422);
+      expect(res.body).toHaveProperty("error", "Expected format { title: <string> }. You are missing a title property.");
+    });
+  });
+});


### PR DESCRIPTION
Add `PUT /playlists/:id` endpoint to the `playlists.js` router with checks for 
- body with title
- id in playlists table
- uniqueness of body


Test does not yet include 500 error catch
Closes Issue #30 