### PR TITLE
Add migration to add playlistFavorites resource to database

### DIFF
--- a/db/migrations/20200211143227_addPlaylistFavorites.js
+++ b/db/migrations/20200211143227_addPlaylistFavorites.js
@@ -1,0 +1,22 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.createTable('playlistFavorites', function(table) {
+      table.increments('id').primary();
+
+      table.integer('playlist_id').unsigned().notNullable();
+      table.foreign('playlist_id').references('id').inTable('playlists');
+
+      table.integer('favorite_id').unsigned().notNullable();
+      table.foreign('favorite_id').references('id').inTable('favorites');
+
+      table.timestamps(true, true)
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.dropTable('playlistFavorites')
+  ]);
+};


### PR DESCRIPTION
Knex migration adds a playlistFavorites resource to the play database.

Run in dev with `knex migrate:latest`
Run in test with `knex migrate:latest --env test`

After merge into master open heroku console and run `knex migrate:latest` to migrate in production

closes #55 

Co-Authored-By: Ryan Hantak <rhantak@users.noreply.github.com>