### PR TITLE
User can delete a favorite from a playlist

### DIFF
--- a/db/migrations/20200211143227_addPlaylistFavorites.js
+++ b/db/migrations/20200211143227_addPlaylistFavorites.js
@@ -1,7 +1,7 @@
 
 exports.up = function(knex) {
   return Promise.all([
-    knex.schema.createTable('playlistFavorites', function(table) {
+    knex.schema.createTable('playlist_favorites', function(table) {
       table.increments('id').primary();
 
       table.integer('playlist_id').unsigned().notNullable();
@@ -17,6 +17,6 @@ exports.up = function(knex) {
 
 exports.down = function(knex) {
   return Promise.all([
-    knex.schema.dropTable('playlistFavorites')
+    knex.schema.dropTable('playlist_favorites')
   ]);
 };

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var router = express.Router();
+var favorites = require('./playlists/favorites');
 
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
@@ -110,5 +111,10 @@ router.delete('/:id', (request, response) => {
       response.status(500).json({ error: "Oops, something went wrong!" })
     })
 })
+
+router.use('/:playlist_id/favorites', function(request, response, next) {
+  request.playlist_id = request.params.playlist_id;
+  next()
+}, favorites);
 
 module.exports = router;

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -1,0 +1,35 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../../knexfile')[environment];
+const database = require('knex')(configuration);
+const Favorite = require("../../../../lib/models/favorite")
+
+router.delete('/:favorite_id', (request, response) => {
+  let playlistId = request.playlist_id
+  let favoriteId = request.params.favorite_id
+
+  database('playlist_favorites').where({playlist_id: playlistId, favorite_id: favoriteId})
+    .del()
+    .then(result => {
+      if(result === 1){
+        response.status(204).send()
+      } else {
+        database('playlists').where({id: playlistId}).select()
+          .then((playlists) => playlists.length === 1)
+          .then(playlistExists => {
+            if(playlistExists){
+            response.status(404).send({"error": "No such favorite found. No deletion made."})
+          } else {
+            response.status(404).send({"error": "No such playlist found. No deletion made."})
+          }
+        })}
+    })
+    .catch(error => {
+      console.log(error)
+      response.status(500).json({ error: "Oops, something went wrong!" })
+    })
+})
+
+module.exports = router;

--- a/tests/deletePlaylistFavorite.spec.js
+++ b/tests/deletePlaylistFavorite.spec.js
@@ -1,0 +1,108 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test the delete playlistFavorite by ids route', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlist_favorites cascade');
+    await database.raw('truncate table favorites cascade');
+    await database.raw('truncate table playlists cascade');
+
+    let playlist = {
+      title: "A Knight's Tale Soundtrack"
+    }
+
+    await database('playlists').insert(playlist, 'id');
+
+    let favorites = [{
+      title: 'We Will Rock You',
+      artistName: 'Queen',
+      genre: 'Rock',
+      rating: 82
+    },
+    {
+      title: 'Low Rider',
+      artistName: 'War',
+      genre: 'Funk',
+      rating: 72
+    },
+    {
+      title: 'The Boys Are Back In Town',
+      artistName: 'Thin Lizzy',
+      genre: 'Rock',
+      rating: 90
+    }];
+
+    await database('favorites').insert(favorites, 'id');
+
+    let faveIds = await database('favorites').pluck('id')
+
+    let playlistId = await database('playlists').select('id').first()
+      .then((firstPlaylist) => firstPlaylist.id)
+
+    let playlistFaves = [{
+      playlist_id: playlistId, favorite_id: faveIds[0]
+    },
+    {
+      playlist_id: playlistId, favorite_id: faveIds[1]
+    },
+    {
+      playlist_id: playlistId, favorite_id: faveIds[2]
+    }];
+
+    await database('playlist_favorites').insert(playlistFaves, 'id');
+  });
+
+  describe('delete favorites from a playlist by id', () => {
+    test('It should respond to the delete method', async() => {
+      let playlistId = await database('playlists').select('id').first()
+        .then((firstPlaylist) => firstPlaylist.id)
+
+      let faveCount = await database('playlist_favorites').where({playlist_id: playlistId}).select()
+        .then((playlistFaves) => playlistFaves.length)
+
+      let favoriteOne = await database('favorites').select().first()
+
+      const res = await request(app)
+        .delete(`/api/v1/playlists/${playlistId}/favorites/${favoriteOne.id}`)
+
+      expect(res.statusCode).toBe(204);
+
+      let newFaveCount = await database('playlist_favorites').where({playlist_id: playlistId}).select()
+          .then((playlistFaves) => playlistFaves.length)
+
+      expect(newFaveCount).toBe(faveCount - 1)
+
+      let notFound = await database('playlist_favorites').where({playlist_id: playlistId, favorite_id: favoriteOne.id}).select()
+        .then((playlistFaves) => playlistFaves.length)
+
+      expect(notFound).toBe(0)
+    })
+
+    test('It should send a 404 if it cannot find a playlist', async() => {
+      let favoriteOne = await database('favorites').select().first()
+
+      const res = await request(app)
+        .delete(`/api/v1/playlists/0/favorites/${favoriteOne.id}`)
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toHaveProperty("error", "No such playlist found. No deletion made.");
+    })
+
+    test('It should send a 404 if it cannot find a favorite', async() => {
+      let playlistId = await database('playlists').select('id').first()
+        .then((firstPlaylist) => firstPlaylist.id)
+
+      const res = await request(app)
+        .delete(`/api/v1/playlists/${playlistId}/favorites/0`)
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toHaveProperty("error", "No such favorite found. No deletion made.");
+    })
+  })
+});


### PR DESCRIPTION
- Add routing for `/playlists/:id/favorites` endpoints
- Add DELETE action for `/api/v1/playlists/favorites/:playlist_id/favorites/:favorite_id` to allow a user to remove a favorite from a playlist

Closes #58 