### PR TITLE
Add a favorite to a playlist with POST /api/v1/playlists/:id/favorites/:id

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Example success response:
 ```
 status: 201
 
-body: 
+body:
 {
   "id": 1,
   "title": "Cleaning House",
@@ -172,7 +172,7 @@ Example success response:
 ```
 status: 200
 
-body: 
+body:
 {
   "id": 3,
   "title": "Morning Jams",
@@ -191,6 +191,20 @@ Example success response:
 status: 204
 ```
 
+##### POST `/playlists/:playlist_id/favorites/:favorite_id`
+Adds a favorite to a playlist
+
+Example request: `POST /api/v1/playlists/1/favorites/1`
+
+Example success response:
+```
+status: 201
+
+body:
+{
+  "Success": "We Will Rock You has been added to Cleaning House!"
+}
+```
 
 ### Schema Design
 

--- a/db/migrations/20200211143227_addPlaylistFavorites.js
+++ b/db/migrations/20200211143227_addPlaylistFavorites.js
@@ -1,7 +1,7 @@
 
 exports.up = function(knex) {
   return Promise.all([
-    knex.schema.createTable('playlistFavorites', function(table) {
+    knex.schema.createTable('playlist_favorites', function(table) {
       table.increments('id').primary();
 
       table.integer('playlist_id').unsigned().notNullable();
@@ -17,6 +17,6 @@ exports.up = function(knex) {
 
 exports.down = function(knex) {
   return Promise.all([
-    knex.schema.dropTable('playlistFavorites')
+    knex.schema.dropTable('playlist_favorites')
   ]);
 };

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -15,10 +15,10 @@ async function fetchMusicData(info) {
         return result.message.body.track_list;
     })
     .catch(error => {
-  console.log(error)
-  response.status(500).json({ error: "Oops, something went wrong!" })
-})
-    return data;
+      console.log(error)
+      response.status(500).json({ error: "Oops, something went wrong!" })
+    })
+  return data;
 }
 
 router.post('/', (request, response) => {

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -1,6 +1,8 @@
 var express = require('express');
 var router = express.Router();
 
+var playlistFavorites = require('./playlists/favorites')
+
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
@@ -110,5 +112,11 @@ router.delete('/:id', (request, response) => {
       response.status(500).json({ error: "Oops, something went wrong!" })
     })
 })
+
+// The fix for our parameters problem
+router.use('/:playlistId/favorites', function(req, res, next) {
+  req.playlistId = req.params.playlistId;
+  next()
+}, playlistFavorites);
 
 module.exports = router;

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var router = express.Router();
 
-var playlistFavorites = require('./playlists/favorites')
+var favorites = require('./playlists/favorites')
 
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
@@ -113,10 +113,9 @@ router.delete('/:id', (request, response) => {
     })
 })
 
-// The fix for our parameters problem
 router.use('/:playlistId/favorites', function(req, res, next) {
   req.playlistId = req.params.playlistId;
   next()
-}, playlistFavorites);
+}, favorites);
 
 module.exports = router;

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -6,12 +6,8 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
-router.get('/', (request, response) => {
-  let playlistId = request.playlistId;
-  return response.send(`${playlistId} and ${info}`)
-})
 
-router.post('/:favoriteId', (request, response) => {
+router.post('/:favorite_id', (request, response) => {
   let playlistId = request.playlist_id
   let favoriteId = request.params.favorite_id
 
@@ -23,12 +19,12 @@ router.post('/:favoriteId', (request, response) => {
       var success = {
         "Success": `${data.favorite_title} has been added to ${data.playlist_title}`
       }
-      database('playlist_favorites').insert({
-        playlist_id: data.playlist_id,
-        favorite_id: data.favorite_id
-      }, 'id')
+      database('playlist_favorites')
+        .insert({
+                  playlist_id: data.playlist_id,
+                  favorite_id: data.favorite_id
+                }, 'id')
       .then(result => {
-
         response.status(201).json(success)
       })
     })

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -1,0 +1,14 @@
+const playlistFavorites = require('express').Router();
+
+// const environment = process.env.NODE_ENV || 'development';
+// const configuration = require('../../../knexfile')[environment];
+// const database = require('knex')(configuration);
+
+playlistFavorites.get('/', (request, response) => {
+  let playlistId = request.playlistId;
+  return response.send(`${playlistId} and ${info}`)
+})
+
+playlistFavorites.
+
+module.exports = playlistFavorites;

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -1,14 +1,81 @@
 const playlistFavorites = require('express').Router();
 
-// const environment = process.env.NODE_ENV || 'development';
-// const configuration = require('../../../knexfile')[environment];
-// const database = require('knex')(configuration);
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../../knexfile')[environment];
+const database = require('knex')(configuration);
 
 playlistFavorites.get('/', (request, response) => {
   let playlistId = request.playlistId;
   return response.send(`${playlistId} and ${info}`)
 })
 
-playlistFavorites.
+playlistFavorites.post('/:favoriteId', (request, response) => {
+  let playlistId = request.playlistId;
+  let favoriteId = request.params.favoriteId;
+
+  // check playlistId is in playlist table
+  // check favoriteId is in favorite table
+  checkIds(playlistId, favoriteId)
+    .then(data =>{
+      success = {
+        "Success": `${data.favorite_title} has been added to ${data.playlist_title}`
+      }
+      response.status(201).json(success)
+    })
+
+  // if both pass, then make new playlist_favorite
+})
+
+async function checkAndGetPlaylist(id){
+  let data = await database('playlists')
+    .where({id: id})
+    .then(results => {
+      if (results.length > 0){
+        return results[0]
+      } else {
+        return response.status(404).send({
+          "error" : "Unable to add favorite to playlist.",
+          "detail" : `Could not find a playlist with id ${id}.`
+        })
+      }
+    })
+    .catch(error => {
+      console.log(error)
+      response.status(500).json({ error: "Oops, something went wrong!" })
+    })
+  return data
+}
+
+async function checkAndGetFavorite(id){
+  let data = await database('favorites')
+    .where({id: id})
+    .then(results => {
+      if (results.length > 0){
+        return results[0]
+      } else {
+        return response.status(404).send({
+          "error" : "Unable to add favorite to playlist.",
+          "detail" : `Could not find a favorite with id ${id}.`
+        })
+      }
+    })
+    .catch(error => {
+      console.log(error)
+      response.status(500).json({ error: "Oops, something went wrong!" })
+    })
+  return data
+}
+
+async function checkIds(playlistId, favoriteId) {
+  let playlist = await checkAndGetPlaylist(playlistId);
+  let favorite = await checkAndGetFavorite(favoriteId);
+  return {  playlist_id: playlist.id,
+            playlist_title: playlist.title,
+            favorite_id: favorite.id,
+            favorite_title: favorite.title
+         }
+}
+
+
 
 module.exports = playlistFavorites;

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -17,13 +17,20 @@ playlistFavorites.post('/:favoriteId', (request, response) => {
   // check favoriteId is in favorite table
   checkIds(playlistId, favoriteId)
     .then(data =>{
-      success = {
+      // if both pass, then make new playlist_favorite
+      var success = {
         "Success": `${data.favorite_title} has been added to ${data.playlist_title}`
       }
-      response.status(201).json(success)
+      database('playlist_favorites').insert({
+        playlist_id: data.playlist_id,
+        favorite_id: data.favorite_id
+      }, 'id')
+      .then(result => {
+
+        response.status(201).json(success)
+      })
     })
 
-  // if both pass, then make new playlist_favorite
 })
 
 async function checkAndGetPlaylist(id){

--- a/routes/api/v1/playlists/favorites.js
+++ b/routes/api/v1/playlists/favorites.js
@@ -18,7 +18,7 @@ router.post('/:favorite_id', (request, response) => {
       // if both pass, then make new playlist_favorite
       if (data["playlist_id"] && data["favorite_id"]){
         var success = {
-          "Success": `${data.favorite_title} has been added to ${data.playlist_title}`
+          "Success": `${data.favorite_title} has been added to ${data.playlist_title}!`
         }
         database('playlist_favorites')
         .insert({

--- a/tests/postPlaylist.spec.js
+++ b/tests/postPlaylist.spec.js
@@ -13,7 +13,7 @@ describe('Test the playlists route', () => {
     fetch.resetMocks();
   });
   afterEach(() => {
-    database.raw('truncate table favorites cascade');
+    database.raw('truncate table playlists cascade');
   });
 
   describe('POST playlists', () => {

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -9,8 +9,32 @@ const database = require('knex')(configuration);
 
 describe('Test the playlistFavorites route', () => {
   beforeEach(async () => {
-    await database.raw('truncate table playlistFavorites cascade');
-    fetch.resetMocks();
+    await database.raw('truncate table playlist_favorites cascade');
+    await database.raw('truncate table favorites cascade');
+    await database.raw('truncate table playlists cascade');
+    let playlist = {
+      title: "A Knight's Tale Soundtrack"
+    }
+    await database('playlists').insert(playlist, 'id');
+    let favorites = [{
+      title: 'We Will Rock You',
+      artistName: 'Queen',
+      genre: 'Rock',
+      rating: 82
+    },
+    {
+      title: 'Low Rider',
+      artistName: 'War',
+      genre: 'Funk',
+      rating: 72
+    },
+    {
+      title: 'The Boys Are Back In Town',
+      artistName: 'Thin Lizzy',
+      genre: 'Rock',
+      rating: 90
+    }];
+    await database('favorites').insert(favorites, 'id');
   });
   afterEach(() => {
     database.raw('truncate table playlistFavorites cascade');
@@ -18,7 +42,24 @@ describe('Test the playlistFavorites route', () => {
 
   describe('POST playlistFavorites', () => {
     test('It should respond to the POST method', async () => {
-      
+      let playlist = await database('playlists').select('id').first()
+        .then((firstPlaylist) => firstPlaylist)
+      let favorite = await database('favorites').select('id').first()
+        .then((firstFavorite) => firstFavorite)
+
+      console.log({playlist: playlist, favorite: favorite})
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlist.id}/favorites/${favorite.id}`)
+
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty("Success", "We Will Rock You has been added to A Knight's Tale Soundtrack");
+
+      playlistFavorites = await database('playlist_favorites').select()
+      expect(playlistFavorites.length).toBe(1)
+      expect(playlistFavorites[0].playlist_id).toBe(playlist.id)
+      expect(playlistFavorites[0].favorite_id).toBe(favorite.id)
+
     })
   })
 });

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -60,7 +60,7 @@ describe('Test the playlistFavorites route', () => {
       expect(playlistFavorites[0].favorite_id).toBe(favorite.id)
 
     })
-    test.only('It should return a 404 if playlist not found', async ()=>{
+    test('It should return a 404 if playlist not found', async ()=>{
       let favorite = await database('favorites').select('id').first()
         .then((firstFavorite) => firstFavorite)
 
@@ -82,6 +82,16 @@ describe('Test the playlistFavorites route', () => {
       expect(res.statusCode).toBe(404)
       expect(res.body).toHaveProperty("error", "Unable to update playlist.");
       expect(res.body).toHaveProperty("detail", "A favorite with that id cannot be found");
+    })
+
+    test('It should return a 404 if neither favorite nor playlist found', async ()=>{
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${0}/favorites/${0}`)
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty("error", "Unable to update playlist.");
+      expect(res.body).toHaveProperty("detail", "A playlist with that id cannot be found");
     })
 
   })

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -52,7 +52,7 @@ describe('Test the playlistFavorites route', () => {
 
 
       expect(res.statusCode).toBe(201);
-      expect(res.body).toHaveProperty("Success", "We Will Rock You has been added to A Knight's Tale Soundtrack");
+      expect(res.body).toHaveProperty("Success", "We Will Rock You has been added to A Knight's Tale Soundtrack!");
 
       playlistFavorites = await database('playlist_favorites').select()
       expect(playlistFavorites.length).toBe(1)

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -47,7 +47,6 @@ describe('Test the playlistFavorites route', () => {
       let favorite = await database('favorites').select('id').first()
         .then((firstFavorite) => firstFavorite)
 
-      console.log({playlist: playlist, favorite: favorite})
       const res = await request(app)
         .post(`/api/v1/playlists/${playlist.id}/favorites/${favorite.id}`)
 

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -1,0 +1,24 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test the playlistFavorites route', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlistFavorites cascade');
+    fetch.resetMocks();
+  });
+  afterEach(() => {
+    database.raw('truncate table playlistFavorites cascade');
+  });
+
+  describe('POST playlistFavorites', () => {
+    test('It should respond to the POST method', async () => {
+      
+    })
+  })
+});

--- a/tests/postPlaylistFavorites.spec.js
+++ b/tests/postPlaylistFavorites.spec.js
@@ -60,5 +60,29 @@ describe('Test the playlistFavorites route', () => {
       expect(playlistFavorites[0].favorite_id).toBe(favorite.id)
 
     })
+    test.only('It should return a 404 if playlist not found', async ()=>{
+      let favorite = await database('favorites').select('id').first()
+        .then((firstFavorite) => firstFavorite)
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${0}/favorites/${favorite.id}`)
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty("error", "Unable to update playlist.");
+      expect(res.body).toHaveProperty("detail", "A playlist with that id cannot be found");
+    })
+
+    test('It should return a 404 if favorite not found', async ()=>{
+      let playlist = await database('playlists').select('id').first()
+        .then((firstPlaylist) => firstPlaylist)
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlist.id}/favorites/${0}`)
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty("error", "Unable to update playlist.");
+      expect(res.body).toHaveProperty("detail", "A favorite with that id cannot be found");
+    })
+
   })
 });


### PR DESCRIPTION
This is a fairly messy solution, and could use refactoring, but I've added the endpoint `post /api/v1/playlists/:id/favorites/:id` that closes #53 

- Route through the /playlists/favorites.js router
- Merged in the `delete` changes and couldn't rebase due to merge conflicts. Those are sorted in this branch.
- Tests for happy path, 404, 400 (uniqueness)

Explanation of async/await functions:
To get a handle on convoluted nested conditionals, I created some `async await` functionality that could be refactored out of this router file and into a playlistsFavorites model. The crux of the logic is held in the `checkIds(playlistId, favoriteId)` function.

I would like to be able to send straight responses from that function, but I don't have access to the `response` method (parameter, argument?) in the async function outside of the router.