### PR TITLE
Refactor get playlists to include favorites

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,19 +115,40 @@ Example success response:
 ```
 {
   data: [
-    {
-      "id": 1,
-      "title": "Cleaning House",
-      "createdAt": 2019-11-26T16:03:43+00:00,
-      "updatedAt": 2019-11-26T16:03:43+00:00
-    },
-    {
-      "id": 2,
-      "title": "Running Mix",
-      "createdAt": 2019-11-26T16:03:43+00:00,
-      "updatedAt": 2019-11-26T16:03:43+00:00
-    },
-  ]
+          {
+            "id": 1,
+            "title": "Cleaning House",
+            "songCount": 2,
+            "songAvgRating": 27.5,
+            "favorites": [
+                            {
+                              "id": 1,
+                              "title": "We Will Rock You",
+                              "artistName": "Queen"
+                              "genre": "Rock",
+                              "rating": 25
+                            },
+                            {
+                              "id": 4,
+                              "title": "Back In Black",
+                              "artistName": "AC/DC"
+                              "genre": "Rock",
+                              "rating": 30
+                            }
+                          ],
+            "createdAt": 2019-11-26T16:03:43+00:00,
+            "updatedAt": 2019-11-26T16:03:43+00:00
+          },
+          {
+            "id": 2,
+            "title": "Running Mix",
+            "songCount": 0,
+            "songAvgRating": 0,
+            "favorites": []
+            "createdAt": 2019-11-26T16:03:43+00:00,
+            "updatedAt": 2019-11-26T16:03:43+00:00
+          },
+        ]
 }
 ```
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -12,8 +12,7 @@ router.get('/', (request, response) => {
   database('playlists')
     .select("playlists.id",
             "playlists.title",
-            database.raw("select json_agg(favorites) from (select * from favorites)")
-            // database.raw("json_agg(favorites) as favorites")
+            database.raw("ARRAY_AGG (row_to_json(favorites)) favorites")
           )
     .sum({ songCount: 'favorites.id' })
     .avg({ songAvgRating: 'favorites.rating' })
@@ -22,6 +21,10 @@ router.get('/', (request, response) => {
     .leftJoin('playlist_favorites', 'playlists.id', 'playlist_favorites.playlist_id')
     .leftJoin('favorites', 'playlist_favorites.favorite_id', 'favorites.id')
     .groupBy('playlists.id')
+  // database('playlists')
+  //   .select(
+  //     database.raw("row_to_json(playlists)")
+  //   )
     .then(result => {
       console.log(result)
       response.status(200).send({data: result})

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -21,10 +21,6 @@ router.get('/', (request, response) => {
     .leftJoin('playlist_favorites', 'playlists.id', 'playlist_favorites.playlist_id')
     .leftJoin('favorites', 'playlist_favorites.favorite_id', 'favorites.id')
     .groupBy('playlists.id')
-  // database('playlists')
-  //   .select(
-  //     database.raw("row_to_json(playlists)")
-  //   )
     .then(result => {
       console.log(result)
       response.status(200).send({data: result})

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -7,10 +7,23 @@ var favorites = require('./playlists/favorites')
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
+
 router.get('/', (request, response) => {
   database('playlists')
-    .select("id", "title", "created_at as createdAt", "updated_at as updatedAt")
+    .select("playlists.id",
+            "playlists.title",
+            database.raw("select json_agg(favorites) from (select * from favorites)")
+            // database.raw("json_agg(favorites) as favorites")
+          )
+    .sum({ songCount: 'favorites.id' })
+    .avg({ songAvgRating: 'favorites.rating' })
+    .select("playlists.created_at as createdAt",
+            "playlists.updated_at as updatedAt")
+    .leftJoin('playlist_favorites', 'playlists.id', 'playlist_favorites.playlist_id')
+    .leftJoin('favorites', 'playlist_favorites.favorite_id', 'favorites.id')
+    .groupBy('playlists.id')
     .then(result => {
+      console.log(result)
       response.status(200).send({data: result})
     })
     .catch(error => {

--- a/tests/getPlaylists.spec.js
+++ b/tests/getPlaylists.spec.js
@@ -65,7 +65,7 @@ describe('Test the playlists route', () => {
       }]
       let inserted = await database('playlist_favorites').insert(playlistFaves, 'id').then((result)=>result);
       console.log(inserted)
-      
+
       const res = await request(app)
         .get("/api/v1/playlists")
 
@@ -79,6 +79,15 @@ describe('Test the playlists route', () => {
       expect(res.body.data[0]).toHaveProperty("songCount");
       expect(res.body.data[0]).toHaveProperty("songAvgRating");
       expect(res.body.data[0]).toHaveProperty("favorites");
+
+      expect(res.body.data[0].favorites[0]).toHaveProperty("title", "We Will Rock You");
+      expect(res.body.data[0].favorites[0]).toHaveProperty("artistName", "Queen");
+      expect(res.body.data[0].favorites[0]).toHaveProperty("genre", "Rock");
+      expect(res.body.data[0].favorites[0]).toHaveProperty("rating", 82);
+
+      expect(res.body.data[0].favorites[1]).toHaveProperty("title", "Low Rider");
+      expect(res.body.data[0].favorites[2]).toHaveProperty("title", "The Boys Are Back In Town");
+
 
       expect(res.body.data[1]).toHaveProperty("title", "Keep Walking");
       expect(res.body.data[1]).toHaveProperty("id");

--- a/tests/getPlaylists.spec.js
+++ b/tests/getPlaylists.spec.js
@@ -28,6 +28,44 @@ describe('Test the playlists route', () => {
 
       await database('playlists').insert(playlistsArray, ['id', 'title']);
 
+      let favoritesArray = [{
+        title: 'We Will Rock You',
+        artistName: 'Queen',
+        genre: 'Rock',
+        rating: 82
+      },
+      {
+        title: 'Low Rider',
+        artistName: 'War',
+        genre: 'Funk',
+        rating: 72
+      },
+      {
+        title: 'The Boys Are Back In Town',
+        artistName: 'Thin Lizzy',
+        genre: 'Rock',
+        rating: 90
+      }];
+
+      await database('favorites').insert(favoritesArray, ['id', 'title']);
+
+      let faveIds = await database('favorites').pluck('id')
+
+      let playlistId = await database('playlists').select('id').first()
+      .then((firstPlaylist) => firstPlaylist.id)
+
+      let playlistFaves = [{
+        playlist_id: playlistId, favorite_id: faveIds[0]
+      },
+      {
+        playlist_id: playlistId, favorite_id: faveIds[1]
+      },
+      {
+        playlist_id: playlistId, favorite_id: faveIds[2]
+      }]
+      let inserted = await database('playlist_favorites').insert(playlistFaves, 'id').then((result)=>result);
+      console.log(inserted)
+      
       const res = await request(app)
         .get("/api/v1/playlists")
 
@@ -38,15 +76,22 @@ describe('Test the playlists route', () => {
       expect(res.body.data[0]).toHaveProperty("id");
       expect(res.body.data[0]).toHaveProperty("createdAt");
       expect(res.body.data[0]).toHaveProperty("updatedAt");
+      expect(res.body.data[0]).toHaveProperty("songCount");
+      expect(res.body.data[0]).toHaveProperty("songAvgRating");
+      expect(res.body.data[0]).toHaveProperty("favorites");
 
       expect(res.body.data[1]).toHaveProperty("title", "Keep Walking");
       expect(res.body.data[1]).toHaveProperty("id");
       expect(res.body.data[1]).toHaveProperty("createdAt");
       expect(res.body.data[1]).toHaveProperty("updatedAt");
+      expect(res.body.data[1]).toHaveProperty("songCount");
+      expect(res.body.data[1]).toHaveProperty("songAvgRating");
+      expect(res.body.data[1]).toHaveProperty("favorites");
 
     });
 
     test("It should respond with an empty array when no playlists present", async() => {
+
       const res = await request(app)
         .get("/api/v1/playlists")
 


### PR DESCRIPTION
the `get /api/v1/playlists` endpoint fetches related favorites for each playlist.

Currently, `null` is returned instead of zeros for no favorites related to playlists.