### PR TITLE
Update get /playlists refactor sql query

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -9,17 +9,17 @@ const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 router.get('/', (request, response) => {
-  database('playlists')
-    .select("playlists.id",
-            "playlists.title",
+  database('favorites')
+    .select('playlists.id',
+            'playlists.title',
+            database.raw('COALESCE(COUNT (favorites), 0) as "songCount"'),
+            database.raw('COALESCE(AVG (favorites.rating), 0) as "songAvgRating"'),
             database.raw("ARRAY_AGG (row_to_json(favorites)) favorites")
-          )
-    .sum({ songCount: 'favorites.id' })
-    .avg({ songAvgRating: 'favorites.rating' })
+    )
     .select("playlists.created_at as createdAt",
             "playlists.updated_at as updatedAt")
-    .leftJoin('playlist_favorites', 'playlists.id', 'playlist_favorites.playlist_id')
-    .leftJoin('favorites', 'playlist_favorites.favorite_id', 'favorites.id')
+    .join('playlist_favorites', 'favorites.id', 'playlist_favorites.favorite_id')
+    .rightJoin('playlists', 'playlist_favorites.playlist_id', 'playlists.id')
     .groupBy('playlists.id')
     .then(result => {
       console.log(result)

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -77,7 +77,7 @@ describe('Test the playlists route', () => {
       expect(res.body.data[0]).toHaveProperty("id");
       expect(res.body.data[0]).toHaveProperty("createdAt");
       expect(res.body.data[0]).toHaveProperty("updatedAt");
-      expect(res.body.data[0]).toHaveProperty("songCount");
+      expect(res.body.data[0]).toHaveProperty("songCount", "3");
       expect(res.body.data[0]).toHaveProperty("songAvgRating");
       expect(res.body.data[0]).toHaveProperty("favorites");
 
@@ -97,6 +97,9 @@ describe('Test the playlists route', () => {
       expect(res.body.data[1]).toHaveProperty("songCount");
       expect(res.body.data[1]).toHaveProperty("songAvgRating");
       expect(res.body.data[1]).toHaveProperty("favorites");
+
+      expect(res.body.data[1]).toHaveProperty("songCount", "0");
+      expect(res.body.data[1]).toHaveProperty("songAvgRating", "0");
 
     });
 


### PR DESCRIPTION
Turns out the query was not returning accurate counts and averages, fixed by re-writing the query to match what I had tried out in postico.